### PR TITLE
fix broken link for Transformers paper

### DIFF
--- a/posts/essential_haskell.md
+++ b/posts/essential_haskell.md
@@ -30,7 +30,7 @@ Here is a list of papers and writings of what I consider are essential Haskell r
 * [Parallel and Concurrent Programming in Haskell](http://chimera.labs.oreilly.com/books/1230000000929)
 * [Beautiful Differentiation](http://conal.net/blog/posts/beautiful-differentiation)
 * [Typed Tagless Interpretations and Typed Compilation](http://okmij.org/ftp/tagless-final/)
-* [Species and Functors and Types, Oh My!](http://www.cis.upenn.edu/~byorgey/papers/species-pearl.pdf)
+* [Species and Functors and Types, Oh My!](http://repository.upenn.edu/cgi/viewcontent.cgi?article=1774&context=cis_papers)
 * [The Implementation of Functional Programming Languages](http://research.microsoft.com/en-us/um/people/simonpj/papers/slpj-book-1987/)
 * [Datatype-generic Programming in Haskell](http://www.andres-loeh.de/DGP-Intro.pdf)
 * [Giving Haskell a Promotion](https://research.microsoft.com/en-us/people/dimitris/fc-kind-poly.pdf)

--- a/posts/essential_haskell.md
+++ b/posts/essential_haskell.md
@@ -12,7 +12,7 @@ Here is a list of papers and writings of what I consider are essential Haskell r
 * [The Essence of Functional Programming](http://homepages.inf.ed.ac.uk/wadler/papers/essence/essence.ps.gz)
 * [How to make ad-hoc polymorphism less ad hoc](http://homepages.inf.ed.ac.uk/wadler/papers/class/class.ps.gz)
 * [Monads for functional programming](http://homepages.inf.ed.ac.uk/wadler/papers/marktoberdorf/baastad.pdf)
-* [Monad Transformers: Step-By-Step](http://www.cs.virginia.edu/~wh5a/personal/Transformers.pdf)
+* [Monad Transformers: Step-By-Step](http://catamorph.de/documents/Transformers.pdf)
 * [Some interesting features of Haskell's type system](https://jeltsch.wordpress.com/2013/02/09/some-interesting-features-of-haskells-type-system/)
 * [Functional Programming with Bananas, Lenses, Envelopes and Barbed Wire](http://eprints.eemcs.utwente.nl/7281/01/db-utwente-40501F46.pdf)
 * [Applicative Programming with Effects](http://strictlypositive.org/IdiomLite.pdf)


### PR DESCRIPTION
Uses a link to [catamorph.de](http://catamorph.de/documents/Transformers.pdf) instead of the previous broken link