### PR TITLE
Fix Rejected/Accepted on LiquidHaskell section

### DIFF
--- a/posts/haskell_2018.md
+++ b/posts/haskell_2018.md
@@ -406,11 +406,11 @@ hasZero (x:xs) = x == 0 || (hasZero xs)
 
 type HasZero = {v : [Int] | (hasZero v)}
 
--- Accepted
+-- Rejected
 xs :: HasZero
 xs = [1,2,3,4]
 
--- Rejected
+-- Accepted
 ys :: HasZero
 ys = [0,1,2,3]
 ```


### PR DESCRIPTION
### Fix Rejected/Accepted on LiquidHaskell section

The code comments are inverted. The 'xs' are Rejected because they
do not satisfy the Prop of containing a zero, while that the 'ys' are
Accepted because they do.