### PR TITLE
Fix uninstantiated template variables in <meta>

### DIFF
--- a/templates/default.html
+++ b/templates/default.html
@@ -9,8 +9,8 @@
   ================================================== -->
     <meta charset="utf-8">
     <title>$title$</title>
-    <meta name="description" content="{{description}}">
-    <meta name="author" content="{{author}}">
+    <meta name="description" content="Personal Blog">
+    <meta name="author" content="Stephen Diehl">
 
     <!-- Mobile Specific Metas
   ================================================== -->


### PR DESCRIPTION
I noticed when viewing your blog in Firefox's "Reader Mode" that it shows the author's name as `{{author}}`.