### PR TITLE
Fix broken Twitter link (for logged-in users)

### DIFF
--- a/templates/default.html
+++ b/templates/default.html
@@ -71,7 +71,7 @@
                     <li><a href="/pages/pgp.html">PGP Key</a></li>
                     <li><a href="https://github.com/sdiehl">Github</a></li>
                     <li><a href="/feed.rss">RSS</a></li>
-                    <li><a href="https://twitter.com/#!/smdiehl">Twitter</a></li>
+                    <li><a href="https://twitter.com/smdiehl">Twitter</a></li>
                 </ul>
             </nav>
             &nbsp;


### PR DESCRIPTION
https://twitter.com/#!/smdiehl forwards logged-in users to their personal dashboard.


(Curiously, it works correctly for logged-out users.)


I've altered it to work for both groups.